### PR TITLE
Potential fix for code scanning alert no. 50: DOM text reinterpreted as HTML

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
@@ -7,7 +7,18 @@ export const onRouteUpdate = (
   const baseProtocol = domElem.getAttribute(`data-baseProtocol`)
   const baseHost = domElem.getAttribute(`data-baseHost`)
   if (existingValue && baseProtocol && baseHost) {
-    let value = `${baseProtocol}//${baseHost}${location.pathname}`
+    const normalizedProtocol = baseProtocol.endsWith(`:`)
+      ? baseProtocol.toLowerCase()
+      : `${baseProtocol.toLowerCase()}:`
+    const safeProtocol =
+      normalizedProtocol === `http:` || normalizedProtocol === `https:`
+    const safeHost = /^[a-z0-9.-]+(?::\d+)?$/i.test(baseHost)
+
+    if (!safeProtocol || !safeHost) {
+      return
+    }
+
+    let value = `${normalizedProtocol}//${baseHost}${location.pathname}`
 
     const { stripQueryString } = pluginOptions
 
@@ -17,6 +28,6 @@ export const onRouteUpdate = (
 
     value += location.hash
 
-    domElem.setAttribute(`href`, `${value}`)
+    domElem.setAttribute(`href`, value)
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/gatsby/security/code-scanning/50](https://github.com/krishnprakash/gatsby/security/code-scanning/50)

Best fix: avoid trusting DOM-provided `data-baseProtocol` and `data-baseHost` directly. Validate and normalize both before constructing `href`, and only allow safe protocols (`http:`/`https:`) and a hostname-like `baseHost`. Then construct the canonical URL from validated pieces and set it.

In `packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js`, update the `if` block so it:
- normalizes protocol (`http:`/`https:` only),
- validates host with a conservative hostname/host:port regex,
- returns early if validation fails,
- uses normalized protocol/host when building `value`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
